### PR TITLE
Fix zookeeper error on provisioning vagrant box

### DIFF
--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -5,6 +5,7 @@
   file:
     path: "{{ zookeeper_config_dir }}"
     state: directory
+    follow: yes
     mode: 0755
   sudo: yes
   tags:


### PR DESCRIPTION
This fixes this error:

```
PLAY [mesos_masters] **********************************************************

TASK: [zookeeper | create zookeeper config directory] *************************
failed: [master1] => {"failed": true, "gid": 0, "group": "root", "mode": "0777", "owner": "root", "path": "/etc/zookeeper/conf", "size": 32, "state": "link", "uid": 0}
msg: /etc/zookeeper/conf already exists as a link

FATAL: all hosts have already failed -- aborting

PLAY RECAP ********************************************************************
           to retry, use: --limit @/Users/risheppa/site.retry

master1                    : ok=38   changed=29   unreachable=0    failed=1

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
➜  Apollo git:(master)
```
